### PR TITLE
Padronização dos controllers

### DIFF
--- a/infra/controller.js
+++ b/infra/controller.js
@@ -1,5 +1,4 @@
 import { InternalServerError, MethodNotAllowedError } from "infra/errors.js";
-import { error } from "node:console";
 
 function onNoMatchHandler(request, response) {
   const publicErrorObject = new MethodNotAllowedError(); // Cria um erro de método não permitido

--- a/infra/controller.js
+++ b/infra/controller.js
@@ -1,0 +1,27 @@
+import { InternalServerError, MethodNotAllowedError } from "infra/errors.js";
+import { error } from "node:console";
+
+function onNoMatchHandler(request, response) {
+  const publicErrorObject = new MethodNotAllowedError(); // Cria um erro de método não permitido
+  response.status(publicErrorObject.statusCode).json(publicErrorObject); // Retorna um erro 405 (Método Não Permitido) se a rota não for encontrada
+}
+
+function onErrorHandler(error, request, response) {
+  const publicErrorObject = new InternalServerError({
+    statusCode: error.statusCode,
+    cause: error,
+  });
+
+  console.error(publicErrorObject);
+
+  response.status(publicErrorObject.statusCode).json(publicErrorObject);
+}
+
+const controller = {
+  errorHandlers: {
+    onNoMatch: onNoMatchHandler,
+    onError: onErrorHandler,
+  },
+};
+
+export default controller; // Exporta o controlador para ser usado nas rotas de API

--- a/infra/database.js
+++ b/infra/database.js
@@ -1,4 +1,5 @@
 import { Client } from "pg";
+import { ServiceError } from "./errors.js";
 
 async function query(queryObject) {
   let client;
@@ -9,9 +10,11 @@ async function query(queryObject) {
     const result = await client.query(queryObject);
     return result;
   } catch (error) {
-    // Se ocorrer um erro, ele será capturado aqui
-    console.error("Erro dentro do catch do database.js:", error);
-    throw error; // Lança o erro para que possa ser tratado onde a função for chamada
+    const publicErrorObject = new ServiceError({
+      message: "Erro na conexão com banco de dados ou na Query.",
+      cause: error,
+    });
+    throw publicErrorObject; // Lança o erro para que possa ser tratado onde a função for chamada
   } finally {
     // Independentemente de ter ocorrido um erro ou não, o cliente será desconectado
     await client?.end();

--- a/infra/errors.js
+++ b/infra/errors.js
@@ -1,11 +1,49 @@
 export class InternalServerError extends Error {
-  constructor({ cause }) {
+  constructor({ cause, statusCode }) {
     super("Um erro interno não esperado aconteceu.", {
       cause,
     });
     this.name = "InternalServerError"; // Define o nome do erro
     this.action = "Entre em contato com o suporte técnico."; // Ação recomendada para o usuário
-    this.statusCode = 500; // Define o código de status HTTP para este erro
+    this.statusCode = statusCode || 500; // Define o código de status HTTP para este erro
+  }
+
+  toJSON() {
+    return {
+      name: this.name,
+      message: this.message,
+      action: this.action,
+      status_code: this.statusCode,
+    };
+  }
+}
+
+export class ServiceError extends Error {
+  constructor({ cause, message }) {
+    super(message || "Serviço indisponível no momento.", {
+      cause,
+    });
+    this.name = "ServiceError"; // Define o nome do erro
+    this.action = "Verifique se o serviço está disponível."; // Ação recomendada para o usuário
+    this.statusCode = 503; // Define o código de status HTTP para este erro
+  }
+
+  toJSON() {
+    return {
+      name: this.name,
+      message: this.message,
+      action: this.action,
+      status_code: this.statusCode,
+    };
+  }
+}
+
+export class MethodNotAllowedError extends Error {
+  constructor() {
+    super("Método não permitido.");
+    this.name = "MethodNotAllowedError"; // Define o nome do erro
+    this.action = "Verifique se o método HTTP está correto."; // Ação recomendada para o usuário
+    this.statusCode = 405; // Define o código de status HTTP para este erro
   }
 
   toJSON() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "dotenv": "17.2.0",
         "dotenv-expand": "12.0.2",
         "next": "15.4.3",
+        "next-connect": "1.0.0",
         "node-pg-migrate": "7.6.1",
         "pg": "8.16.3",
         "react": "18.3.1",
@@ -3066,6 +3067,12 @@
       "dependencies": {
         "tslib": "^2.8.0"
       }
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.0",
@@ -10587,6 +10594,19 @@
         }
       }
     },
+    "node_modules/next-connect": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/next-connect/-/next-connect-1.0.0.tgz",
+      "integrity": "sha512-FeLURm9MdvzY1SDUGE74tk66mukSqL6MAzxajW7Gqh6DZKBZLrXmXnGWtHJZXkfvoi+V/DUe9Hhtfkl4+nTlYA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tsconfig/node16": "^1.0.3",
+        "regexparam": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/node-abort-controller": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-3.1.1.tgz",
@@ -11974,6 +11994,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/regexparam": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/regexparam/-/regexparam-2.0.2.tgz",
+      "integrity": "sha512-A1PeDEYMrkLrfyOwv2jwihXbo9qxdGD3atBYQA9JJgreAx8/7rC6IUkWOw2NQlOxLp2wL0ifQbh1HuidDfYA6w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/remarkable": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "dotenv": "17.2.0",
     "dotenv-expand": "12.0.2",
     "next": "15.4.3",
+    "next-connect": "1.0.0",
     "node-pg-migrate": "7.6.1",
     "pg": "8.16.3",
     "react": "18.3.1",

--- a/pages/api/v1/migrations/index.js
+++ b/pages/api/v1/migrations/index.js
@@ -54,7 +54,6 @@ import migrationRunner from "node-pg-migrate";
 import { resolve } from "node:path";
 import database from "infra/database.js";
 import controller from "infra/controller.js"; // Importa os manipuladores de erro e rota não encontrada
-import db from "node-pg-migrate/dist/db";
 
 const router = createRouter();
 

--- a/pages/api/v1/status/index.js
+++ b/pages/api/v1/status/index.js
@@ -33,53 +33,48 @@
  *                           example: 1
  */
 
+import { createRouter } from "next-connect";
 import database from "infra/database.js"; // Importa a função que conecta com o banco de dados
-import { InternalServerError } from "infra/errors";
+import controller from "infra/controller.js"; // Importa os manipuladores de erro e rota não encontrada
 
-async function status(request, response) {
-  try {
-    const updateAt = new Date().toISOString(); // Pega a data e hora atual do servidor
+const router = createRouter();
 
-    const databaseVersionResult = await database.query("SHOW server_version;");
-    const databaseVersionValue = databaseVersionResult.rows[0].server_version; // Obtém a versão do banco de dados
+router.get(getHandler); // Define a rota GET para listar migrações pendentes
 
-    const databaseMaxConnectionsResult = await database.query(
-      "SHOW max_connections;",
-    ); //Perguntamos ao banco de dados qual é o número máximo de conexões permitidas
-    const databaseMaxConnectionsValue = parseInt(
-      databaseMaxConnectionsResult.rows[0].max_connections,
-    ); // Converte para inteiro, pois o resultado vem como texto
+export default router.handler(controller.errorHandlers); // Exporta o manipulador de erros e rota não encontrada
 
-    const databaseName = process.env.POSTGRES_DB; // Nome do banco de dados que estamos usando
-    const databaseOpenedConnectionsResult = await database.query({
-      text: "SELECT COUNT(*)::int FROM pg_stat_activity WHERE datname = $1;", // Conta quantas conexões estão abertas no banco de dados
-      values: [databaseName], // Passa o nome do banco de dados como parâmetro
-    });
-    const databaseOpenedConnectionsValue =
-      databaseOpenedConnectionsResult.rows[0].count; // Obtém o número de conexões abertas
+async function getHandler(request, response) {
+  const updateAt = new Date().toISOString(); // Pega a data e hora atual do servidor
 
-    response.status(200).json({
-      // Retornamos um status 200 (OK)
+  const databaseVersionResult = await database.query("SHOW server_version;");
+  const databaseVersionValue = databaseVersionResult.rows[0].server_version; // Obtém a versão do banco de dados
 
-      updated_at: updateAt, // A data e hora da última atualização
-      dependencies: {
-        // Dependências do sistema
-        database: {
-          version: databaseVersionValue, // A versão do banco de dados
-          max_connections: databaseMaxConnectionsValue, // O número máximo de conexões permitidas no banco de dados
-          opened_connections: databaseOpenedConnectionsValue, // O número de conexões abertas no banco de dados
-        },
+  const databaseMaxConnectionsResult = await database.query(
+    "SHOW max_connections;",
+  ); //Perguntamos ao banco de dados qual é o número máximo de conexões permitidas
+  const databaseMaxConnectionsValue = parseInt(
+    databaseMaxConnectionsResult.rows[0].max_connections,
+  ); // Converte para inteiro, pois o resultado vem como texto
+
+  const databaseName = process.env.POSTGRES_DB; // Nome do banco de dados que estamos usando
+  const databaseOpenedConnectionsResult = await database.query({
+    text: "SELECT COUNT(*)::int FROM pg_stat_activity WHERE datname = $1;", // Conta quantas conexões estão abertas no banco de dados
+    values: [databaseName], // Passa o nome do banco de dados como parâmetro
+  });
+  const databaseOpenedConnectionsValue =
+    databaseOpenedConnectionsResult.rows[0].count; // Obtém o número de conexões abertas
+
+  response.status(200).json({
+    // Retornamos um status 200 (OK)
+
+    updated_at: updateAt, // A data e hora da última atualização
+    dependencies: {
+      // Dependências do sistema
+      database: {
+        version: databaseVersionValue, // A versão do banco de dados
+        max_connections: databaseMaxConnectionsValue, // O número máximo de conexões permitidas no banco de dados
+        opened_connections: databaseOpenedConnectionsValue, // O número de conexões abertas no banco de dados
       },
-    });
-  } catch (error) {
-    const publicErrorObject = new InternalServerError({
-      cause: error,
-    });
-
-    console.error(" Erro dentro do catch do controller:", publicErrorObject);
-
-    response.status(500).json(publicErrorObject);
-  }
+    },
+  });
 }
-
-export default status; // Exporta a função para que ela possa ser usada como uma rota de API

--- a/tests/integration/api/v1/migrations/delete.test.js
+++ b/tests/integration/api/v1/migrations/delete.test.js
@@ -1,0 +1,27 @@
+import orchestrator from "tests/orchestrator.js";
+
+beforeAll(async () => {
+  // Aguarda todos os serviços necessários estarem prontos antes de iniciar os testes
+  await orchestrator.waitForAllServices();
+  await orchestrator.clearDatabase(); // Limpa o banco de dados antes de iniciar os testes
+});
+
+describe("DELETE /api/v1/migrations", () => {
+  describe("Anonymous user", () => {
+    test("Deleting pending migrations", async () => {
+      const response = await fetch("http://localhost:3000/api/v1/migrations", {
+        method: "DELETE",
+      });
+
+      expect(response.status).toBe(405);
+
+      const responseBody = await response.json();
+      expect(responseBody).toEqual({
+        name: "MethodNotAllowedError",
+        message: "Método não permitido.",
+        action: "Verifique se o método HTTP está correto.",
+        status_code: 405,
+      });
+    });
+  });
+});

--- a/tests/integration/api/v1/status/post.test.js
+++ b/tests/integration/api/v1/status/post.test.js
@@ -1,0 +1,26 @@
+import orchestrator from "tests/orchestrator.js";
+
+// Executa antes de todos os testes
+beforeAll(async () => {
+  // Aguarda todos os serviços necessários estarem prontos antes de iniciar os testes
+  await orchestrator.waitForAllServices();
+});
+
+describe("POST /api/v1/status", () => {
+  describe("Anonymous user", () => {
+    test("Retrieving current system status", async () => {
+      const response = await fetch("http://localhost:3000/api/v1/status", {
+        method: "POST",
+      });
+      expect(response.status).toBe(405);
+
+      const responseBody = await response.json();
+      expect(responseBody).toEqual({
+        name: "MethodNotAllowedError",
+        message: "Método não permitido.",
+        action: "Verifique se o método HTTP está correto.",
+        status_code: 405,
+      });
+    });
+  });
+});


### PR DESCRIPTION
1. Padroniza os Controllers dos endpoints: `/migrations` e `/status`.
2. Adiciona 2 novos erros customizados: `ServiceError` e `MethodNotAllowedError`.
3. Faz o `InternalServerError` aceitar injeção do `StatusCode`